### PR TITLE
Change Giftcard PIN prefill

### DIFF
--- a/panel.js
+++ b/panel.js
@@ -527,7 +527,11 @@ function prefillCardComponent(type, cardNumberTd, expiryTd, codeTd) {
     if (code != null) {
       if (codeTd === "ANY") {
         // replace ANY placeholder with valid code
-        codeTd = "123";
+        if (type == "giftcard") {
+          codeTd = "100";  // default PIN for giftcards
+        } else {
+          codeTd = "123"; // default CVC for cards
+        }
       }
       if (codeTd === "None") {
         // replace None placeholder with empty code


### PR DESCRIPTION
Use value `100` as code when prefilling Gift Card PIN

Fix #21 