### PR TITLE
Copy text on click

### DIFF
--- a/data/giftcards.json
+++ b/data/giftcards.json
@@ -1,25 +1,25 @@
 [
     {
         "cardnumber" : "6036280000000000000",
-        "code" : "123",
+        "code" : "100",
         "type" : "Givex",
         "logo" : "givex"
     },
     {
         "cardnumber" : "6364530000000000",
-        "code" : "123",
+        "code" : "100",
         "type" : "Generic",
         "logo" : "giftcard"
     },
     {
         "cardnumber" : "6006490000000000",
-        "code" : "123",
+        "code" : "100",
         "type" : "SVS",
         "logo" : "svs"
     },
     {
         "cardnumber" : "7777182708544835",
-        "code" : "123",
+        "code" : "100",
         "type" : "Fiserv",
         "logo" : "giftcard"
     }    

--- a/data/giftcards.json
+++ b/data/giftcards.json
@@ -1,25 +1,25 @@
 [
     {
         "cardnumber" : "6036280000000000000",
-        "code" : "ANY",
+        "code" : "123",
         "type" : "Givex",
         "logo" : "givex"
     },
     {
         "cardnumber" : "6364530000000000",
-        "code" : "ANY",
+        "code" : "123",
         "type" : "Generic",
         "logo" : "giftcard"
     },
     {
         "cardnumber" : "6006490000000000",
-        "code" : "ANY",
+        "code" : "123",
         "type" : "SVS",
         "logo" : "svs"
     },
     {
         "cardnumber" : "7777182708544835",
-        "code" : "ANY",
+        "code" : "123",
         "type" : "Fiserv",
         "logo" : "giftcard"
     }    

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,33 +9,23 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.35.1"
+        "@playwright/test": "^1.40.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
-      "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "dev": true,
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.35.1"
+        "playwright": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
         "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "20.3.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.3.tgz",
-      "integrity": "sha512-wheIYdr4NYML61AjC8MKj/2jrR/kDQri/CIpVoZwldwhnIrD/j9jIU5bJ8yBKuB2VhpFV7Ab6G2XkBjv9r9Zzw==",
-      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -51,10 +41,28 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.40.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
     "node_modules/playwright-core": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
-      "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,6 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.35.1"
+    "@playwright/test": "^1.40.0"
   }
 }

--- a/e2e/tests/test-extension.spec.ts
+++ b/e2e/tests/test-extension.spec.ts
@@ -79,12 +79,12 @@ test('copy Giftcard details', async ({ page, extensionId }) => {
     expect(clipboard).toContain("6036280000000000000");
 
     // code
-    let code = page.locator('text="123"').first();
+    let code = page.locator('text="100"').first();
     await expect(code).toBeVisible();
     await code.click();
 
     clipboard = await page.evaluate("navigator.clipboard.readText()");
-    expect(clipboard).toContain("123");
+    expect(clipboard).toContain("100");
 
 });
 

--- a/e2e/tests/test-extension.spec.ts
+++ b/e2e/tests/test-extension.spec.ts
@@ -2,38 +2,110 @@ import { test, expect } from './fixtures';
 
 // verify filter
 test('filter', async ({ page, extensionId }) => {
-  await page.goto(`chrome-extension://${extensionId}/panel.html`);
+    await page.goto(`chrome-extension://${extensionId}/panel.html`);
 
-  await expect(page.locator('text="Filter:"')).toBeVisible();
+    // use filter
+    await expect(page.locator('text="Filter:"')).toBeVisible();
+    await page.locator('input').pressSequentially('Mastercard', { delay: 100 });
 
-  await page.locator('input[id="search"]').type("Mastercard");
-  // Mastercard visible
-  await expect(page.locator('text="2222 4000 7000 0005"')).toBeVisible();
-  // Maestro not visible
-  await expect(page.locator('text="6771 7980 2100 0008"')).not.toBeVisible();
+    // Mastercard visible
+    await expect(page.locator('text="2222 4000 7000 0005"')).toBeVisible();
+    // Maestro not visible
+    await expect(page.locator('text="6771 7980 2100 0008"')).not.toBeVisible();
+    // IBAN not visible
+    await expect(page.locator('text="NL36TEST0236169114"')).not.toBeVisible();
+});
+
+// verify favourites message
+test('fav', async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/panel.html`);
+
+    await expect(page.locator('text="Add favourites if you like :-)"')).toBeVisible();
+});
+
+// verify copy card to clipboard
+test('copy card details', async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/panel.html`);
+
+    // card number
+    let cardnumber = page.locator('text="4871 0499 9999 9910"');
+    await expect(cardnumber).toBeVisible();
+    await cardnumber.click();
+
+    let clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("4871 0499 9999 9910");
+
+    // cvc
+    let cvc = page.locator('text="7373"').first();
+    await expect(cvc).toBeVisible();
+    await cvc.click();
+
+    clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("7373");
+});
+
+// verify copy IBAN to clipboard
+test('copy IBAN details', async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/panel.html`);
+
+    // IBAN
+    let iban = page.locator('text="IT60X0542811101000000123456"');
+    await expect(iban).toBeVisible();
+    await iban.click();
+
+    let clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("IT60X0542811101000000123456");
+
+    // name
+    let name = page.locator('text="A. Pacini"');
+    await expect(name).toBeVisible();
+    await name.click();
+
+    clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("A. Pacini");
 
 });
 
-// verify copy card number to clipboard
-test('copy', async ({ page, extensionId }) => {
+// verify copy Giftcard to clipboard
+test('copy Giftcard details', async ({ page, extensionId }) => {
+    await page.goto(`chrome-extension://${extensionId}/panel.html`);
+
+    // card number
+    let cardnumber = page.locator('text="6036280000000000000"');
+    await expect(cardnumber).toBeVisible();
+    await cardnumber.click();
+
+    let clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("6036280000000000000");
+
+    // code
+    let code = page.locator('text="123"').first();
+    await expect(code).toBeVisible();
+    await code.click();
+
+    clipboard = await page.evaluate("navigator.clipboard.readText()");
+    expect(clipboard).toContain("123");
+
+});
+
+// verify make favourite
+test('make favourite', async ({ page, extensionId }) => {
 
     await page.goto(`chrome-extension://${extensionId}/panel.html`);
-  
-    const firstRow = await page.$('tr');
-    if(firstRow == null) {
-        throw new Error("firstRow not found");
-    }
+    // empty favs message is visible
+    await expect(page.locator('text="Add favourites if you like :-)"')).toBeVisible();
 
-    const copyLink = await firstRow.$(`a.copyLinkClick`);
-    if(copyLink == null) {
-        throw new Error("copyLink not found");
-    }
+    // pin card in favs
+    await page.click("[id='4871_0499_9999_9910']");
+    await page.waitForTimeout(1000);
 
-    await copyLink.click(); 
+    // empty favs message is hidden
+    await expect(page.locator('text="Add favourites if you like :-)"')).not.toBeVisible();
 
-    // clipboard includes first card number
-    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
-    expect(clipboardText).toBe("3700 0000 0000 002");
-  
+    // unpin card from favs
+    await page.click("[id='4871_0499_9999_9910']");
+    await page.waitForTimeout(1000);
+
+    // empty favs message is visible
+    await expect(page.locator('text="Add favourites if you like :-)"')).toBeVisible();
 });
-

--- a/panel.css
+++ b/panel.css
@@ -191,3 +191,18 @@ a {
   justify-content: space-between;
   align-items: center;  
 }
+
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background-color: #fff;
+  color: black;
+  padding: 10px;
+  text-align: center;
+}
+
+main {
+  margin-top: 25px; 
+}

--- a/panel.css
+++ b/panel.css
@@ -9,6 +9,10 @@ body {
   display: none;
 }
 
+.visible {
+  display: inline-block;
+}
+
 a {
   color: #06f;
   cursor: pointer;
@@ -26,7 +30,7 @@ a {
 }
 
 .cardnumbers td {
-  padding: 4px;
+  padding: 3px;
   border-bottom: 1pt solid #33b964;
 }
 
@@ -173,4 +177,16 @@ a {
   background-position: center;
   background-size: 30px 30px; 
   min-width: 30px;
+}
+
+.copyable:hover {
+  cursor: pointer;
+  position: relative;
+}
+
+
+.divFavouritesContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;  
 }

--- a/panel.css
+++ b/panel.css
@@ -19,10 +19,6 @@ a {
   text-align: center;
 }
 
-.hidden {
-  display: none;
-}
-
 .cardnumbers {
   border-collapse: collapse;
   width: 100%;

--- a/panel.css
+++ b/panel.css
@@ -3,6 +3,7 @@ body {
   font-family: Verdana, Geneva, sans-serif;
   font-size: 12px;
   font-weight: 100;
+  margin: 4px;
 }
 
 .hidden {

--- a/panel.html
+++ b/panel.html
@@ -5,10 +5,13 @@
     <script src="third-party/jquery-3.7.0.min.js"></script>
   </head>
   <body>
-    <p>All our Test card numbers on <a href="https://docs.adyen.com/development-resources/testing/test-card-numbers" target="_blank">Adyen docs</a></p>
-    <div>Filter: <input id="search" autocomplete="off"/></div>
-    <div id="cards">
-    </div>
+    <header id="header"></header>
+    <main class="content">
+      <div><p>All our Test card numbers on <a href="https://docs.adyen.com/development-resources/testing/test-card-numbers" target="_blank">Adyen docs</a></p></div>
+      <div>Filter: <input id="search" autocomplete="off"/></div>
+      <div id="cards">
+      </div>
+    </main>
     <script src="panel.js"></script>
   </body>
 </html>

--- a/panel.js
+++ b/panel.js
@@ -105,11 +105,7 @@ function createFavourites() {
   // Favourites title and helper messages
   var divFavouritesContainer = $('<div>').addClass("divFavouritesContainer");
   var h3 = $('<h3>').addClass("sectionTitle").text("Favourites");
-  // message when hovering over text
-  var copyToClipboardMessageSpan = $('<span>').attr('id', 'copyToClipboardMessageSpanId').addClass("hidden").text("Click to copy in the clipboard");
-  // message when text is copied
-  var textIsCopiedMessageSpan = $('<span>').attr('id', 'textIsCopiedMessageSpanId').addClass("hidden").html("Copied &#x2705;");
-  divFavouritesContainer.append(h3, copyToClipboardMessageSpan, textIsCopiedMessageSpan);
+  divFavouritesContainer.append(h3);
 
   divFavourites.append(divFavouritesContainer);
 
@@ -207,20 +203,7 @@ function addCopyHandlers(element) {
   // make it copyable
   element.addClass("copyable");
   // set handlers
-  element.hover(onHoverHandler).click(copyToClipboardHandler)
-}
-
-// when hovering over copiable text
-// display helper message
-function onHoverHandler() {
-  $(this).hover(function() {
-    if($('#textIsCopiedMessageSpanId').is(':visible')) {
-      return;
-    }
-    $('#copyToClipboardMessageSpanId').show();
-  }, function() {
-    $('#copyToClipboardMessageSpanId').hide();
-  });
+  element.click(copyToClipboardHandler)  
 }
 
 // when copying into the clipboard

--- a/panel.js
+++ b/panel.js
@@ -2,9 +2,9 @@
 const THREE_DS_SUFFIX = " (3DS)";
 
 // name objects on local storage
-const CARDS_LIST = "cards"
-const GIFTCARDS_LIST = "giftcards2"
-const IBANS_LIST = "ibans"
+const CARDS_LIST = "cards-list"
+const GIFTCARDS_LIST = "giftcards-list"
+const IBANS_LIST = "ibans-list"
 
 let cards = [];
 let giftcards = [];
@@ -101,8 +101,17 @@ function createCards() {
 function createFavourites() {
 
   var divFavourites = $('<div>').addClass("cardnumbers");
+
+  // Favourites title and helper messages
+  var divFavouritesContainer = $('<div>').addClass("divFavouritesContainer");
   var h3 = $('<h3>').addClass("sectionTitle").text("Favourites");
-  divFavourites.append(h3);
+  // message when hovering over text
+  var copyToClipboardMessageSpan = $('<span>').attr('id', 'copyToClipboardMessageSpanId').addClass("hidden").text("Click to copy in the clipboard");
+  // message when text is copied
+  var textIsCopiedMessageSpan = $('<span>').attr('id', 'textIsCopiedMessageSpanId').addClass("hidden").html("Copied &#x2705;");
+  divFavouritesContainer.append(h3, copyToClipboardMessageSpan, textIsCopiedMessageSpan);
+
+  divFavourites.append(divFavouritesContainer);
 
   let numFavs = 0;
 
@@ -120,16 +129,19 @@ function createFavourites() {
 
         var row = $('<tr>');
         var tdIcon = ($('<td>').append(makeCardUnfavIcon(item.cardnumber)));
+
+        var cardnumber = item.cardnumber;
         if (item.secure3DS) {
           // add suffix when card flow supports 3DS ie 3714 4963 5398 431 (3DS)
-          var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber + THREE_DS_SUFFIX));
-        } else {
-          var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
-        }
-        // add as hidden (not visible but be able to get the value when prefilling card component)
-        var tdExpiry = ($('<td>').addClass("hidden").addClass("tdExpiry").text(item.expiry));
-        // add as hidden (not visible but be able to get the value when prefilling card component)
-        var tdCode = ($('<td>').addClass("hidden").addClass("tdCode").text(item.CVC));
+          cardnumber = cardnumber + THREE_DS_SUFFIX;
+        } 
+        var tdNumber = $('<td>').addClass("tdCardNumber").text(cardnumber);
+        addCopyHandlers(tdNumber);
+
+        var tdExpiry = ($('<td>').addClass("tdExpiry").text(item.expiry));
+        addCopyHandlers(tdExpiry);
+        var tdCode = ($('<td>').addClass("tdCode").text(item.CVC));
+        addCopyHandlers(tdCode);
         var tdLogo = ($('<td>').addClass("center").addClass(logo).attr('title', group));
         var tdLinks = ($('<td>').addClass("center").append(createLinks("card")));
         row.append(tdIcon).append(tdNumber).append(tdExpiry).append(tdCode).append(tdLogo).append(tdLinks);
@@ -150,8 +162,9 @@ function createFavourites() {
       var row = $('<tr>').addClass("searchable");
       var tdIcon = ($('<td>').append(makeGiftCardUnfavIcon(item.cardnumber)));
       var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
-        // add as hidden (not visible but be able to get the value when prefilling card component)
-        var tdCode = ($('<td>').addClass("hidden").addClass("tdCode").text(item.code));
+      addCopyHandlers(tdNumber);
+      var tdCode = ($('<td colspan="2">').addClass("center").addClass("tdCode").text(item.code));
+      addCopyHandlers(tdCode);
       var tdLogo = ($('<td>').addClass("center").addClass(logo).attr('title', item.type));
       var tdLinks = ($('<td>').addClass("center").append(createLinks("giftcard")));
       row.append(tdIcon).append(tdNumber).append(tdCode).append(tdLogo).append(tdLinks);
@@ -168,8 +181,9 @@ function createFavourites() {
       var row = $('<tr>').addClass("searchable");
       var tdIcon = ($('<td>').append(makeIbanUnfavIcon(item.iban)));
       var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.iban));
-      // add as hidden (not visible but be able to get the value when prefilling card component)
-      var tdCode = ($('<td>').addClass("hidden").addClass("tdExpiry").text(item.name));  // note: use expiry column for IBAN account holder
+      addCopyHandlers(tdNumber);
+      var tdCode = ($('<td colspan="2">').addClass("center").addClass("tdExpiry").text(item.name));  // note: use expiry column for IBAN account holder
+      addCopyHandlers(tdCode);
       var tdLogo = ($('<td>').addClass("center").text("IBAN"));
       var tdLinks = ($('<td>').addClass("center").append(createLinks("iban")));
       row.append(tdIcon).append(tdNumber).append(tdCode).append(tdLogo).append(tdLinks);
@@ -303,21 +317,24 @@ function createCardsBrandSection(brand, cards) {
       numCards++;
 
       var row = $('<tr>').addClass("searchable");
-      var td0 = ($('<td>').append(makeCardFavIcon(item.cardnumber)));
+      var tdIcon = ($('<td>').append(makeCardFavIcon(item.cardnumber)));
       if (item.secure3DS) {
         // add suffix when card flow supports 3DS ie 3714 4963 5398 431 (3DS)
-        var td1 = ($('<td>').addClass("tdCardNumber").text(item.cardnumber + THREE_DS_SUFFIX));
+        var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber + THREE_DS_SUFFIX));
         // add hidden cell to allow filtering on content (cardnumber, brand, etc..)
         var tdHidden = ($('<td>').addClass("hidden").text(brand + " " + item.cardnumber + THREE_DS_SUFFIX));
       } else {
-        var td1 = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
+        var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
         // add hidden cell to allow filtering on content (cardnumber, brand, etc..)
         var tdHidden = ($('<td>').addClass("hidden").text(brand + " " + item.cardnumber));
       }
-      var td2 = ($('<td>').addClass("center").addClass("tdExpiry").text(item.expiry));
-      var td3 = ($('<td>').addClass("center").addClass("tdCode").text(item.CVC));
-      var td4 = ($('<td>').addClass("center").append(createLinks("card")));
-      row.append(tdHidden).append(td0).append(td1).append(td2).append(td3).append(td4);
+      addCopyHandlers(tdNumber);
+      var tdExpiry = ($('<td>').addClass("center").addClass("tdExpiry").text(item.expiry));
+      addCopyHandlers(tdExpiry);
+      var tdCode = ($('<td>').addClass("center").addClass("tdCode").text(item.CVC));
+      addCopyHandlers(tdCode);
+      var tdLinks = ($('<td>').addClass("center").append(createLinks("card")));
+      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdExpiry).append(tdCode).append(tdLinks);
       table.append(row);
     }
   });
@@ -347,12 +364,14 @@ function createGiftCards() {
       var row = $('<tr>').addClass("searchable");
       // add hidden cell to allow filtering on content (number, code, etc..)
       var tdHidden = ($('<td>').addClass("hidden").text("giftcards " + item.cardnumber + " " + item.type));
-      var td0 = ($('<td>').append(makeGiftCardFavIcon(item.cardnumber)));
-      var td1 = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
-      var td2 = ($('<td>').addClass("tdType").text(item.type));
-      var td3 = ($('<td>').addClass("center").addClass("tdCode").text(item.code));
-      var td4 = ($('<td>').addClass("center").append(createLinks("giftcard")));
-      row.append(tdHidden).append(td0).append(td1).append(td2).append(td3).append(td4);
+      var tdIcon = ($('<td>').append(makeGiftCardFavIcon(item.cardnumber)));
+      var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.cardnumber));
+      addCopyHandlers(tdNumber);
+      var tdType = ($('<td>').addClass("tdType").text(item.type));
+      var tdCode = ($('<td>').addClass("center").addClass("tdCode").text(item.code));
+      addCopyHandlers(tdCode)
+      var tdLinks = ($('<td>').addClass("center").append(createLinks("giftcard")));
+      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdType).append(tdCode).append(tdLinks);
       table.append(row);
     }
   });
@@ -383,11 +402,13 @@ function createIbans() {
       var row = $('<tr>').addClass("searchable");
       // add hidden cell to allow filtering on content (number, name, etc..)
       var tdHidden = ($('<td>').addClass("hidden").text("ibans " + item.iban + " " + item.name));
-      var td0 = ($('<td>').append(makeIbanFavIcon(item.iban)));
-      var td1 = ($('<td>').addClass("tdCardNumber").text(item.iban));
-      var td2 = ($('<td>').addClass("tdExpiry").text(item.name));  // note: use expiry column for IBAN account holder
-      var td3 = ($('<td>').addClass("center").append(createLinks("iban")));
-      row.append(tdHidden).append(td0).append(td1).append(td2).append(td3);
+      var tdIcon = ($('<td>').append(makeIbanFavIcon(item.iban)));
+      var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.iban));
+      addCopyHandlers(tdNumber);
+      var tdName = ($('<td>').addClass("tdExpiry").text(item.name));  // note: use expiry column for IBAN account holder
+      addCopyHandlers(tdName)
+      var tdLinks = ($('<td>').addClass("center").append(createLinks("iban")));
+      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdName).append(tdLinks);
       table.append(row);
     }
   });
@@ -490,6 +511,7 @@ function createCopyLink() {
 
   return anchor
 }
+
 
 // create prefill link based on type (card, giftcard, iban, etc..)
 function createPrefillLink(type) {

--- a/panel.js
+++ b/panel.js
@@ -616,14 +616,6 @@ function prefillCardComponent(type, cardNumberTd, expiryTd, codeTd) {
     var code = document.querySelector('input[id^="adyen-checkout-encryptedSecurityCode-"]');
 
     if (code != null) {
-      if (codeTd === "ANY") {
-        // replace ANY placeholder with valid code
-        if (type == "giftcard") {
-          codeTd = "100";  // default PIN for giftcards
-        } else {
-          codeTd = "123"; // default CVC for cards
-        }
-      }
       if (codeTd === "None") {
         // replace None placeholder with empty code
         codeTd = "";

--- a/panel.js
+++ b/panel.js
@@ -201,6 +201,45 @@ function createFavourites() {
   return divFavourites;
 }
 
+// add handlers (hover, click, etc..)
+function addCopyHandlers(element) {
+  // make it copyable
+  element.addClass("copyable");
+  // set handlers
+  element.hover(onHoverHandler).click(copyToClipboardHandler)
+}
+
+// when hovering over copiable text
+// display helper message
+function onHoverHandler() {
+  $(this).hover(function() {
+    if($('#textIsCopiedMessageSpanId').is(':visible')) {
+      return;
+    }
+    $('#copyToClipboardMessageSpanId').show();
+  }, function() {
+    $('#copyToClipboardMessageSpanId').hide();
+  });
+}
+
+// when copying into the clipboard
+function copyToClipboardHandler() {
+  var value = $(this).text().trim();
+  // remove suffix (if found)
+  value = value.replace(THREE_DS_SUFFIX, "")
+  copyToClipboard(value);
+
+   // Show the message
+   $('#textIsCopiedMessageSpanId').show();
+   // Hide other message 
+   $('#copyToClipboardMessageSpanId').hide();
+
+   // Hide after x seconds
+   setTimeout(function() {
+    $('#textIsCopiedMessageSpanId').hide()
+   }, 1000 * 2);
+}
+
 // add card to favourites
 function makeCardFav(cardnumber) {
 

--- a/panel.js
+++ b/panel.js
@@ -528,7 +528,7 @@ function makeIbanUnfavIcon(iban) {
 
 // create action links (copy, prefill)   
 function createLinks(type) {
-  return $('<div>').addClass("actionLinks").append(createCopyLink()).append("&nbsp;&nbsp;&nbsp;").append(createPrefillLink(type));
+  return $('<div>').addClass("actionLinks").append("&nbsp;&nbsp;&nbsp;").append(createPrefillLink(type));
 }
 
 function createCopyLink() {

--- a/panel.js
+++ b/panel.js
@@ -116,7 +116,8 @@ function createFavourites() {
   let numFavs = 0;
 
   // find favourite cards
-  var table = $('<table>');
+  var table = $('<table>').attr("id", "tableFavouritesId");
+
   $.each(cards, function (index, item) {
 
     const logo = item.logo;
@@ -462,7 +463,7 @@ function createIbans() {
 
 // icon to add card in favourites
 function makeCardFavIcon(cardnumber) {
-  var div = $('<div>').addClass("fav-icon");
+  var div = $('<div>').attr("id", sanitize(cardnumber)).addClass("fav-icon");
 
   div.on('click', function () {
     makeCardFav(cardnumber);
@@ -473,7 +474,7 @@ function makeCardFavIcon(cardnumber) {
 
 // icon to remove card from favourites
 function makeCardUnfavIcon(cardnumber) {
-  var div = $('<div>').addClass("unfav-icon");
+  var div = $('<div>').attr("id", sanitize(cardnumber)).addClass("unfav-icon");
 
   div.on('click', function () {
     makeCardUnfav(cardnumber);
@@ -702,6 +703,10 @@ async function loadFromFile(filename) {
   return obj;
 }
 
+// replace space with underscore
+function sanitize(str) {
+  return str.replace(/ /g, '_');
+}
 
 document.addEventListener('DOMContentLoaded', function () {
   load();

--- a/panel.js
+++ b/panel.js
@@ -213,14 +213,12 @@ function copyToClipboardHandler() {
   value = value.replace(THREE_DS_SUFFIX, "")
   copyToClipboard(value);
 
-   // Show the message
-   $('#textIsCopiedMessageSpanId').show();
-   // Hide other message 
-   $('#copyToClipboardMessageSpanId').hide();
+   // Show message "Copied!"
+   $('#header').html("Copied &#x2705;");
 
    // Hide after x seconds
    setTimeout(function() {
-    $('#textIsCopiedMessageSpanId').hide()
+    $('#header').html("");
    }, 1000 * 2);
 }
 


### PR DESCRIPTION
This PR reworks the `copy-to-clipboard` feature:

- The copy link is removed
- Each copiable element (card number, expiry date, CVC, IBAN, etc..) is copied by clicking on the text
- A fixed (always visible when scrolling) header displays a message when an item is clicked and copied into the clipboard
- The Favourites section includes extra information (expiry date, CVC, IBAN holder), these fields can also be copied into the clipboard 

Fix #22 