### PR TITLE
Display card issuing country

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -31,13 +31,13 @@
             {
                 "cardnumber" : "6703 4444 4444 4449",
                 "expiry" : "03/30",
-                "CVC" : "None",
+                "CVC" : "n/a",
                 "country" : "BE"
             },
             {
                 "cardnumber" : "6703 0000 0000 0000 003",
                 "expiry" : "03/30",
-                "CVC" : "None",
+                "CVC" : "n/a",
                 "country" : "BE"
             }
         ]
@@ -68,6 +68,7 @@
                 "cardnumber" : "4035 5014 2814 6300",
                 "expiry" : "03/30",
                 "CVC" : "737",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -110,7 +111,7 @@
                 "cardnumber" : "6250 9470 0000 0014",
                 "expiry" : "03/30",
                 "CVC" : "123",
-                "country" : "n/a",
+                "country" : "CN",
                 "secure3DS" : true
             }
         ]
@@ -178,7 +179,7 @@
             {
                 "cardnumber" : "5000 5500 0000 0029",
                 "expiry" : "03/30",
-                "CVC" : "None",
+                "CVC" : "n/a",
                 "country" : "n/a",
                 "secure3DS" : true
             }

--- a/data/cards.json
+++ b/data/cards.json
@@ -6,17 +6,20 @@
             {
                 "cardnumber" : "3700 0000 0000 002",
                 "expiry" : "03/30",
-                "CVC" : "7373"
+                "CVC" : "7373",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "3700 0000 0100 018",
                 "expiry" : "03/30",
-                "CVC" : "7373"
+                "CVC" : "7373",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "3714 4963 5398 431",
                 "expiry" : "03/30",
                 "CVC" : "7373",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -28,12 +31,14 @@
             {
                 "cardnumber" : "6703 4444 4444 4449",
                 "expiry" : "03/30",
-                "CVC" : "None"
+                "CVC" : "None",
+                "country" : "BE"
             },
             {
                 "cardnumber" : "6703 0000 0000 0000 003",
                 "expiry" : "03/30",
-                "CVC" : "None"
+                "CVC" : "None",
+                "country" : "BE"
             }
         ]
     },
@@ -44,7 +49,8 @@
             {
                 "cardnumber" : "4871 0499 9999 9910",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "BE"
             }
         ]
     },
@@ -55,7 +61,8 @@
             {
                 "cardnumber" : "4360 0000 0100 0005",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "FR"
             },
             {
                 "cardnumber" : "4035 5014 2814 6300",
@@ -72,7 +79,8 @@
             {
                 "cardnumber" : "4035 5010 0000 0008",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "FR"
             }
         ]
     },
@@ -83,22 +91,26 @@
             {
                 "cardnumber" : "8171 9999 2766 0000",
                 "expiry" : "10/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CN"
             },
             {
                 "cardnumber" : "8171 9999 0000 0000 021",
                 "expiry" : "10/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CN"
             },
             {
                 "cardnumber" : "6243 0300 0000 0001",
                 "expiry" : "12/29",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CN"
             },
             {
                 "cardnumber" : "6250 9470 0000 0014",
                 "expiry" : "03/30",
                 "CVC" : "123",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -110,12 +122,14 @@
             {
                 "cardnumber" : "3600 6666 3333 44",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "US"
             },
             {
                 "cardnumber" : "3607 0500 0010 20",
                 "expiry" : "03/30",
                 "CVC" : "737",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -127,12 +141,14 @@
             {
                 "cardnumber" : "6011 6011 6011 6611",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "US"
             },
             {
                 "cardnumber" : "6445 6445 6445 6445",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "GB"
             },
             {
                 "cardnumber" : "3056 9309 0259 04",
@@ -148,12 +164,14 @@
             {
                 "cardnumber" : "6771 7980 2100 0008",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "US"
             },
             {
                 "cardnumber" : "5000 5500 0000 0029",
                 "expiry" : "03/30",
                 "CVC" : "None",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -165,78 +183,93 @@
             {
                 "cardnumber" : "2222 4000 7000 0005",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CA"
             },
             {
                 "cardnumber" : "5555 3412 4444 1115",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "5577 0000 5577 0004",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "PL"
             }, 
             {
                 "cardnumber" : "5555 4444 3333 1111",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "GB"
             },
 
             {
                 "cardnumber" : "2222 4107 4036 0010",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "5555 5555 5555 4444",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "GB"
             },
             {
                 "cardnumber" : "2222 4107 0000 0002",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "2222 4000 1000 0008",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CA"
             },
             {
                 "cardnumber" : "2223 0000 4841 0010",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "2222 4000 6000 0007",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CA"
             },
             {
                 "cardnumber" : "2223 5204 4356 0010",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "2222 4000 3000 0004",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CA"
             },
             {
                 "cardnumber" : "5100 0600 0000 0002",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "US"
             },
             {
                 "cardnumber" : "2222 4000 5000 0009",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "CA"
             },
             {
                 "cardnumber" : "5103 2219 1119 9245",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "BR"
             }
         ]
     },
@@ -247,37 +280,44 @@
             {
                 "cardnumber" : "4111 1111 4555 1142",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             },
             {
                 "cardnumber" : "4111 1120 1426 7661",
                 "expiry" : "12/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "FR"
             },
             {
                 "cardnumber" : "4988 4388 4388 4305",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "ES"
             }, 
             {
                 "cardnumber" : "4166 6766 6766 6746",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             }, 
             {
                 "cardnumber" : "4111 1111 1111 1111",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "NL"
             }, 
             {
                 "cardnumber" : "4444 3333 2222 1111",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "GB"
             }, 
             {
                 "cardnumber" : "4917 6100 0000 0000",
                 "expiry" : "03/30",
                 "CVC" : "737",
+                "country" : "n/a",
                 "secure3DS" : true
             }
         ]
@@ -289,7 +329,8 @@
             {
                 "cardnumber" : "4001 0200 0000 0009",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "BR"
             }
         ]
     },
@@ -300,7 +341,8 @@
             {
                 "cardnumber" : "4013 2500 0000 0000 006",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "PL"
             }
         ]
     }

--- a/data/cards.json
+++ b/data/cards.json
@@ -129,6 +129,12 @@
                 "cardnumber" : "3607 0500 0010 20",
                 "expiry" : "03/30",
                 "CVC" : "737",
+                "country" : "NL"
+            },
+            {
+                "cardnumber" : "3056 9309 0259 04",
+                "expiry" : "03/30",
+                "CVC" : "737",
                 "country" : "n/a",
                 "secure3DS" : true
             }
@@ -151,9 +157,11 @@
                 "country" : "GB"
             },
             {
-                "cardnumber" : "3056 9309 0259 04",
+                "cardnumber" : "6011 1111 1111 1117",
                 "expiry" : "03/30",
-                "CVC" : "737"
+                "CVC" : "737",
+                "country" : "n/a",
+                "secure3DS" : true
             }
         ]
     },

--- a/data/cards.json
+++ b/data/cards.json
@@ -68,7 +68,7 @@
                 "cardnumber" : "4035 5014 2814 6300",
                 "expiry" : "03/30",
                 "CVC" : "737",
-                "country" : "n/a",
+                "country" : "FR",
                 "secure3DS" : true
             }
         ]

--- a/panel.js
+++ b/panel.js
@@ -134,7 +134,6 @@ function createFavourites() {
         } 
         var tdNumber = $('<td>').addClass("tdCardNumber").text(cardnumber);
         addCopyHandlers(tdNumber);
-
         var tdExpiry = ($('<td>').addClass("tdExpiry").text(item.expiry));
         addCopyHandlers(tdExpiry);
         var tdCode = ($('<td>').addClass("tdCode").text(item.CVC));
@@ -350,13 +349,15 @@ function createCardsBrandSection(brand, cards) {
         var tdHidden = ($('<td>').addClass("hidden").text(brand + " " + item.cardnumber));
       }
       addCopyHandlers(tdNumber);
+      var tdCountry = ($('<td>').addClass("center").addClass("tdCountry").text(item.country));
+      addCopyHandlers(tdCountry);
       var tdExpiry = ($('<td>').addClass("center").addClass("tdExpiry").text(item.expiry));
       addCopyHandlers(tdExpiry);
       var tdCode = ($('<td>').addClass("center").addClass("tdCode").text(item.CVC));
       addCopyHandlers(tdCode);
       var tdLinks = ($('<td>').addClass("center").append(createLinks("card")));
-      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdExpiry).append(tdCode).append(tdLinks);
-      table.append(row);
+      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdCountry).append(tdExpiry).append(tdCode).append(tdLinks);
+      table.append(row);  
     }
   });
 
@@ -426,10 +427,12 @@ function createIbans() {
       var tdIcon = ($('<td>').append(makeIbanFavIcon(item.iban)));
       var tdNumber = ($('<td>').addClass("tdCardNumber").text(item.iban));
       addCopyHandlers(tdNumber);
+      var tdCountry = ($('<td>').addClass("tdCountry").text(item.country));
+      addCopyHandlers(tdCountry); 
       var tdName = ($('<td>').addClass("tdExpiry").text(item.name));  // note: use expiry column for IBAN account holder
       addCopyHandlers(tdName)
       var tdLinks = ($('<td>').addClass("center").append(createLinks("iban")));
-      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdName).append(tdLinks);
+      row.append(tdHidden).append(tdIcon).append(tdNumber).append(tdCountry).append(tdName).append(tdLinks);
       table.append(row);
     }
   });


### PR DESCRIPTION
This PR displays an additional column to display the issuing country for cards and country for IBANs. This PR also fixed the discrepancy in Diner and Discover card types to make it consistent with the [Adyen Test Cards](https://docs.adyen.com/development-resources/testing/test-card-numbers/) docs page.

Fix #26 