### PR TITLE
Adding expiry date to giftcards.json

### DIFF
--- a/data/giftcards.json
+++ b/data/giftcards.json
@@ -2,24 +2,28 @@
     {
         "cardnumber" : "6036280000000000000",
         "code" : "100",
+        "expiry" : "03/30",
         "type" : "Givex",
         "logo" : "givex"
     },
     {
         "cardnumber" : "6364530000000000",
         "code" : "100",
+        "expiry" : "03/30",
         "type" : "Generic",
         "logo" : "giftcard"
     },
     {
         "cardnumber" : "6006490000000000",
         "code" : "100",
+        "expiry" : "03/30",
         "type" : "SVS",
         "logo" : "svs"
     },
     {
         "cardnumber" : "7777182708544835",
         "code" : "100",
+        "expiry" : "03/30",
         "type" : "Fiserv",
         "logo" : "giftcard"
     }    


### PR DESCRIPTION
## Summary
This PR adds `expiry` to the giftcards.json

## Background
Some giftcards have an expiry date (which for the test cards can just be a random 4 digit string) as mentioned [here](https://docs.adyen.com/point-of-sale/testing-pos-payments/#gift-card-numbers)

